### PR TITLE
Prepare Contributing for move to Hyperledger Labs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ you have the right to submit the code.
 
 If you are a developer who is authorized to contribute to Perun on behalf of
 your employer, then please use your corporate email address in the
-Signed-off-by tag. Otherwise please use a personal email address.
+Signed-off-by tag, otherwise use a personal email address.
 
 [SubmittingPatches]:
 https://github.com/wking/signed-off-by/blob/7d71be37194df05c349157a2161c7534feaf86a4/Documentation/SubmittingPatches

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 ## Process for creating a new proposal
 
 1. Create an
-   [issue](https://github.com/direct-state-transfer/dst-go/issues/new?template=improvement.md)
-   in the dst-go repository, briefly describing the proposal. For
+   [issue](https://github.com/direct-state-transfer/perun-node/issues/new?template=improvement.md)
+   in the perun-node repository, briefly describing the proposal. For
    smaller changes this may be enough. More involved issues may warrant
    creating a detailed proposal.
 
@@ -41,31 +41,82 @@ license used by this project. By raising a PR and signing off your
 commits as described below, you certify that this is the case for your
 contribution.
 
-### Sign the CLA and sign your work
+### Sign your work
 
-We believe that if successful the DST project should move to a neutral
-home in the long run (e.g. to some not-for-profit foundation). To allow
-us to retain the necessary open source licensing flexibility please
-ensure you have signed the [Contributor License Agreement
-(CLA)](https://cla-assistant.io/direct-state-transfer/dst-proposal)
-before creating any pull request. All contributors will retain ownership
-in their contributions while granting us the necessary legal rights. The
-CLA only needs to be signed once and it covers all [Direct State
-Transfer](https://github.com/direct-state-transfer) repositories.
+This project tracks patch provenance and licensing using the Developer
+Certificate of Origin and Signed-off-by tags initially developed by
+the Linux kernel project.
 
-This project also tracks patch provenance and licensing using
-Signed-off-by tags. With the sign-off in a commit message you certify
-that you authored the patch or otherwise have the right to submit it
-under an open source license and you acknowledge that the CLA signed for
-any DST project also applies to this contribution. The procedure is
-simple: just append a line
+```text
+Developer Certificate of Origin
+Version 1.1
 
-    Signed-off-by: Random J Developer <random@developer.example.org>
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
 
-to every commit message using your real name or your pseudonym and a
-valid email address.
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+With the sign-off in a commit message you certify that you authored the
+patch or otherwise have the right to submit it under an open source
+license. The procedure is simple: To certify above Developer's
+Certificate of Origin 1.1 for your contribution just append a line
+
+```text
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+to every commit message using your real name or your pseudonym and a valid
+email address.
 
 If you have set your `user.name` and `user.email` git configs you can
-automatically sign the commit by running the git-commit command with the
-`-s` option.  There may be multiple sign-offs if more than one developer
-was involved in authoring the contribution.
+automatically sign the commit by running the git-commit command with the `-s`
+option.  There may be multiple sign-offs if more than one developer was
+involved in authoring the contribution.
+
+For a more detailed description of this procedure, please see
+[SubmittingPatches][] which was extracted from the Linux kernel project, and
+which is stored in an external repository.
+
+### Individual vs. Corporate Contributors
+
+Often employers or academic institution have ownership over code that is
+written in certain circumstances, so please do due diligence to ensure that
+you have the right to submit the code.
+
+If you are a developer who is authorized to contribute to Perun on behalf of
+your employer, then please use your corporate email address in the
+Signed-off-by tag. Otherwise please use a personal email address.
+
+[SubmittingPatches]:
+https://github.com/wking/signed-off-by/blob/7d71be37194df05c349157a2161c7534feaf86a4/Documentation/SubmittingPatches


### PR DESCRIPTION
Update the perun-proposals contributing guide for the [move to Hyperledger labs](https://github.com/hyperledger-labs/hyperledger-labs.github.io/pull/136):
 - replace CLA with DCO 1.1
 - rename dst-go --> perun-node
